### PR TITLE
Make sure /etc/sudoers.d file is not writeable

### DIFF
--- a/src/coretoolbox.rs
+++ b/src/coretoolbox.rs
@@ -533,6 +533,9 @@ mod entrypoint {
         // Allow sudo
         || -> Fallible<()> {
             let f = std::fs::File::create(format!("/etc/sudoers.d/toolbox-{}", state.username))?;
+            let mut perms = f.metadata()?.permissions();
+            perms.set_readonly(true);
+            f.set_permissions(perms)?;
             let mut f = std::io::BufWriter::new(f);
             writeln!(&mut f, "{} ALL=(ALL) NOPASSWD: ALL", state.username)?;
             f.flush()?;
@@ -656,7 +659,6 @@ mod entrypoint {
             }
         }
     }
-
 }
 
 /// Primary entrypoint


### PR DESCRIPTION
Without explicitly setting the permissions to readonly on this file,
sudoers refuses to read it as world writeable. This leads to sudo
not actually working inside the toolbox container.