### PR TITLE
Add github action to publish release artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: "Publish release artifacts"
+# Publishes release artifacts when a git tag is pushed that starts with v
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  build:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --release
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/release/coretoolbox
+          asset_name: coretoolbox
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
This adds an action which runs when a "v*" tag is pushed to the
repo. This action does a basic release build on ubuntu-latest and
then creates a release and uploads the release binary to that
release.